### PR TITLE
Enable configuration of additional watch tasks

### DIFF
--- a/src/main/java/com/bluepapa32/gradle/plugins/watch/WatchTask.java
+++ b/src/main/java/com/bluepapa32/gradle/plugins/watch/WatchTask.java
@@ -14,7 +14,9 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
+import groovy.lang.Closure;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.tasks.TaskAction;
 
 import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
@@ -24,7 +26,7 @@ import static java.nio.file.StandardWatchEventKinds.OVERFLOW;
 
 public class WatchTask extends DefaultTask {
 
-    private Collection<WatchTarget> targets;
+    private NamedDomainObjectContainer<WatchTarget> targets;
     private Path projectPath;
 
     public WatchTask() {
@@ -35,14 +37,25 @@ public class WatchTask extends DefaultTask {
         return targets;
     }
 
-    public void watch(Collection<WatchTarget> targets) {
+    public void watch(NamedDomainObjectContainer<WatchTarget> targets) {
         this.targets = targets;
+    }
+
+    public void watch(Closure closure) {
+        ensureExistingWatchTargetContainer();
+        targets.configure(closure);
+    }
+
+    private void ensureExistingWatchTargetContainer() {
+        if (targets == null) {
+            targets = getProject().container(WatchTarget.class);
+        }
     }
 
     @TaskAction
     public void watch() throws IOException {
 
-        if (targets == null || targets.isEmpty()) {
+        if (targets.isEmpty()) {
             return;
         }
 

--- a/src/test/groovy/com/bluepapa32/gradle/plugins/watch/WatchPluginSpec.groovy
+++ b/src/test/groovy/com/bluepapa32/gradle/plugins/watch/WatchPluginSpec.groovy
@@ -39,4 +39,24 @@ class WatchPluginSpec extends GradlePluginSpecification {
         tasks.findByPath('watchTest') == null
         tasks.findByPath('watchHoge') == null
     }
+
+    def "configure additional task"() {
+        setup:
+        apply plugin: 'com.bluepapa32.watch'
+
+        when:
+        task('watchTest', type:WatchTask) {
+            watch {
+                tests {
+                    files fileTree(dir: '/src/test/java', include: '**.java')
+                    tasks 'hui', 'buh'
+                }
+            }
+        }
+
+        then:
+        tasks['watchTest'] instanceof WatchTask
+        tasks['watchTest'].targets.size() == 1
+        tasks['watchTest'].targets['tests'] instanceof WatchTarget
+    }
 }


### PR DESCRIPTION
Hi,

this is a proposal to enable the (easy) configuration of additional watch tasks. My use case is to support the definition of watch tasks with overlapping watched directories, e.g. src/test/groovy with only compileTest and one tasks with the execution of tests. 

With this change you can now simply do the following while having full backwards compatibility:

``` groovy
watch {
  java {
    files ...
    tasks ...
  }
}

task watchWithTest(type: WatchTask) {
  watch {
    groovyTests {
      files fileTree(dir: 'src/test/groovy', include: '**.groovy')
      tasks 'check'
    }
  }
}
```
